### PR TITLE
[volum-5] 상품 조회 성능 상향을 위한 처리

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
@@ -15,6 +16,7 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
 
     // DataFaker
     implementation("net.datafaker:datafaker:2.4.4")

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -15,4 +15,7 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+
+    // DataFaker
+    implementation("net.datafaker:datafaker:2.4.4")
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCriteria.java
@@ -5,6 +5,7 @@ import com.loopers.domain.order.Quantity;
 import com.loopers.domain.payment.PaymentCommand;
 import com.loopers.domain.product.ProductInfo;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,7 @@ public class OrderCriteria {
             Long userId,
             int totalPrice
     ) {
-        public static PaymentCommand.Payment toCommand(Long userId, int totalPrice) {
+        public static PaymentCommand.Payment toCommand(Long userId, BigDecimal totalPrice) {
             return new PaymentCommand.Payment(userId, totalPrice);
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
@@ -4,6 +4,7 @@ import com.loopers.domain.order.OrderInfo;
 import com.loopers.domain.order.OrderItemEntity;
 import com.loopers.support.enums.OrderStatus;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public record OrderResult(
@@ -11,7 +12,7 @@ public record OrderResult(
         Long userId,
         OrderStatus status,
         List<OrderItemEntity> orderItems,
-        int totalPrice
+        BigDecimal totalPrice
 ) {
     public static OrderResult from(OrderInfo orderInfo) {
         return new OrderResult(

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointCriteria.java
@@ -2,11 +2,13 @@ package com.loopers.application.point;
 
 import com.loopers.domain.point.PointCommand;
 
+import java.math.BigDecimal;
+
 public class PointCriteria {
 
     public record Charge(
             String loginId,
-            Long amount
+            BigDecimal amount
     ) {
         public PointCommand.Charge toCommand() {
             return new PointCommand.Charge(loginId, amount);

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointResult.java
@@ -2,10 +2,12 @@ package com.loopers.application.point;
 
 import com.loopers.domain.point.PointInfo;
 
+import java.math.BigDecimal;
+
 public record PointResult(
         Long id,
         String loginId,
-        Long amount
+        BigDecimal amount
 ) {
     public static PointResult from(final PointInfo pointInfo) {
         return new PointResult(

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCriteria.java
@@ -2,12 +2,14 @@ package com.loopers.application.product;
 
 import com.loopers.domain.product.ProductCommand;
 
+import java.math.BigDecimal;
+
 public class
 ProductCriteria {
     public record Create(
             String name,
             String description,
-            int price,
+            BigDecimal price,
             int stock,
             Long brandId
     ) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -38,6 +38,15 @@ public class ProductFacade {
     }
 
     @Transactional(readOnly = true)
+    public List<Optional<ProductResult>> getProductsByBrandId(ProductQuery.GetProductsByBrandId query) {
+        List<ProductInfo> products = productService.getProductsByBrandId(query.brandId(), query.pageable());
+
+        Map<Long, Optional<BrandInfo>> brandMap = getBrandMap(products);
+
+        return mergeProductAndBrand(products, brandMap);
+    }
+
+    @Transactional(readOnly = true)
     public Optional<ProductResult> getProduct(Long productId) {
         ProductInfo product = productService.getProduct(productId);
         Optional<BrandInfo> brandInfo = brandService.getBrandInfo(product.brandId());

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -5,6 +5,7 @@ import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.ProductWithBrand;
 import com.loopers.support.enums.SortType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -38,12 +39,10 @@ public class ProductFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<Optional<ProductResult>> getProductsByBrandId(ProductQuery.GetProductsByBrandId query) {
-        List<ProductInfo> products = productService.getProductsByBrandId(query.brandId(), query.pageable());
+    public List<ProductWithBrand> getProductsByBrandId(ProductQuery.GetProductsByBrandId query) {
+        List<ProductWithBrand> products = productService.getProductsByBrandId(query.brandId(), query.pageable());
 
-        Map<Long, Optional<BrandInfo>> brandMap = getBrandMap(products);
-
-        return mergeProductAndBrand(products, brandMap);
+        return products;
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQuery.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQuery.java
@@ -1,0 +1,11 @@
+package com.loopers.application.product;
+
+import org.springframework.data.domain.Pageable;
+
+public class ProductQuery {
+    public record GetProductsByBrandId(
+            Long brandId,
+            Pageable pageable
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -11,7 +11,7 @@ public record ProductResult(
         String description,
         BigDecimal price,
         int stock,
-        Long likeCount,
+        int likeCount,
         Long brandId,
         String brandName,
         String brandDescription

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -3,11 +3,13 @@ package com.loopers.application.product;
 import com.loopers.domain.brand.BrandInfo;
 import com.loopers.domain.product.ProductInfo;
 
+import java.math.BigDecimal;
+
 public record ProductResult(
         Long id,
         String name,
         String description,
-        int price,
+        BigDecimal price,
         int stock,
         Long likeCount,
         Long brandId,

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -6,6 +6,8 @@ import com.loopers.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+
 @RequiredArgsConstructor
 @Component
 public class UserFacade {
@@ -16,7 +18,7 @@ public class UserFacade {
     public UserResult signUp(final UserCriteria.SignUp criteria) {
         final UserResult userResult = UserResult.from(userService.signUp(criteria.toCommand()));
 
-        pointService.initPoint(new PointCommand.Init(criteria.loginId(), 100L));
+        pointService.initPoint(new PointCommand.Init(criteria.loginId(), BigDecimal.valueOf(100L)));
 
         return userResult;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.order;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public class OrderCommand{
@@ -7,5 +8,5 @@ public class OrderCommand{
     public record Order(Long userId, List<OrderItem> orderItems) {
     }
 
-    public record OrderItem(Long productId, Quantity quantity, int price) {}
+    public record OrderItem(Long productId, Quantity quantity, BigDecimal price) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,9 +42,9 @@ public class OrderEntity extends BaseEntity {
         this.status = status;
     }
 
-    public int calculateTotalPrice() {
+    public BigDecimal calculateTotalPrice() {
         return orderItems.stream()
-                .mapToInt(OrderItemEntity::calculateTotalPrice)
-                .sum();
+                .map(OrderItemEntity::calculateTotalPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -2,6 +2,7 @@ package com.loopers.domain.order;
 
 import com.loopers.support.enums.OrderStatus;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public record OrderInfo(
@@ -9,7 +10,7 @@ public record OrderInfo(
         Long userId,
         OrderStatus status,
         List<OrderItemEntity> orderItems,
-        int totalPrice
+        BigDecimal totalPrice
 ) {
     public static OrderInfo from(OrderEntity orderEntity) {
         return new OrderInfo(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemEntity.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 
 @Getter
 @Entity
@@ -21,9 +23,9 @@ public class OrderItemEntity extends BaseEntity {
     @Embedded
     private Quantity quantity;
 
-    private int price;
+    private BigDecimal price;
 
-    public OrderItemEntity(Long productId, Quantity quantity, int price) {
+    public OrderItemEntity(Long productId, Quantity quantity, BigDecimal price) {
         if (productId == null) {
             throw new IllegalArgumentException("productId는 null일 수 없습니다.");
         }
@@ -32,7 +34,7 @@ public class OrderItemEntity extends BaseEntity {
             throw new IllegalArgumentException("quantity는 null이거나 0 이하일 수 없습니다.");
         }
 
-        if (price <= 0) {
+        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("price는 0 이하일 수 없습니다.");
         }
 
@@ -41,7 +43,7 @@ public class OrderItemEntity extends BaseEntity {
         this.price = price;
     }
 
-    public int calculateTotalPrice() {
-        return this.quantity.getQuantity() * this.price;
+    public BigDecimal calculateTotalPrice() {
+        return price.multiply(BigDecimal.valueOf(quantity.getQuantity()));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -1,8 +1,10 @@
 package com.loopers.domain.payment;
 
+import java.math.BigDecimal;
+
 public class PaymentCommand {
     public record Payment(
             Long userId,
-            int totalPrice
+            BigDecimal totalPrice
     ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointCommand.java
@@ -1,19 +1,21 @@
 package com.loopers.domain.point;
 
+import java.math.BigDecimal;
+
 public class PointCommand {
 
     public record Init(
             String loginId,
-            Long amount
+            BigDecimal amount
     ) {}
 
     public record Charge(
             String loginId,
-            Long amount
+            BigDecimal amount
     ) {}
 
     public record Use(
             String loginId,
-            Long amount
+            BigDecimal amount
     ){}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -7,40 +7,44 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "point")
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class PointEntity extends BaseEntity {
     private LoginId loginId;
-    private Long amount;
+    private BigDecimal amount;
 
-    public PointEntity(final LoginId loginId, final Long amount) {
+    public PointEntity(final LoginId loginId, final BigDecimal amount) {
         if (loginId == null) {
             throw new IllegalArgumentException("로그인 ID는 null일 수 없습니다.");
         }
 
-        if (amount != null && amount <= 0) {
-            throw new IllegalArgumentException("충전할 포인트는 0보다 커야 합니다.");
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("포인트 금액은 null이거나 0보다 작을 수 없습니다.");
         }
         this.loginId = loginId;
         this.amount = amount;
     }
 
-    public void charge(Long amount) {
-        if (amount == null || amount <= 0) {
+    public void charge(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("충전할 포인트는 0보다 커야 합니다.");
         }
-        this.amount += amount;
+
+        this.amount = this.amount.add(amount);
     }
 
-    public void use(Long amount) {
-        if (amount == null || amount <= 0) {
+    public void use(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("사용할 포인트는 0보다 커야 합니다.");
         }
-        if (this.amount < amount) {
-            throw new IllegalArgumentException("포인트가 부족합니다.");
+        if (this.amount.compareTo(amount) < 0) {
+            throw new IllegalArgumentException("사용할 포인트가 현재 보유 포인트보다 많습니다.");
         }
-        this.amount -= amount;
+
+        this.amount = this.amount.subtract(amount);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointInfo.java
@@ -2,10 +2,12 @@ package com.loopers.domain.point;
 
 import com.loopers.domain.user.LoginId;
 
+import java.math.BigDecimal;
+
 public record PointInfo(
         Long id,
         LoginId loginId,
-        Long amount
+        BigDecimal amount
 ) {
     public static PointInfo from(final PointEntity pointEntity) {
         return new PointInfo(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
@@ -2,11 +2,13 @@ package com.loopers.domain.product;
 
 import com.loopers.domain.order.Quantity;
 
+import java.math.BigDecimal;
+
 public class ProductCommand {
     public record Create(
             String name,
             String description,
-            int price,
+            BigDecimal price,
             int stock,
             Long brandId
     ) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "product")
 @Getter
@@ -15,14 +17,14 @@ import lombok.NoArgsConstructor;
 public class ProductEntity extends BaseEntity {
     private String name;
     private String description;
-    private int price;
+    private BigDecimal price;
     private int stock;
     private Long brandId;
 
     public ProductEntity(
             final String name,
             final String description,
-            final int price,
+            final BigDecimal price,
             final int stock,
             final Long brandId
     ) {
@@ -32,8 +34,8 @@ public class ProductEntity extends BaseEntity {
         if (description == null) {
             throw new IllegalArgumentException("상품 설명은 null일 수 없습니다.");
         }
-        if (price <= 0) {
-            throw new IllegalArgumentException("상품 가격은 0 이하일 수 없습니다.");
+        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("상품 가격은 0보다 커야 합니다.");
         }
         if (stock < 0) {
             throw new IllegalArgumentException("상품 재고는 음수일 수 없습니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -52,6 +52,22 @@ public class ProductEntity extends BaseEntity {
         this.brandId = brandId;
     }
 
+    public ProductEntity(String name, String description, BigDecimal price, int stock, Long brandId, Integer likeCount) {
+        this(name, description, price, stock, brandId);
+        this.likeCount = likeCount != null ? likeCount : 0;
+    }
+
+    public static ProductEntity create(
+            final String name,
+            final String description,
+            final BigDecimal price,
+            final int stock,
+            final Long brandId,
+            final Integer likeCount
+    ) {
+        return new ProductEntity(name, description, price, stock, brandId, likeCount);
+    }
+
     public void increaseStock(int quantity) {
         if (quantity <= 0) {
             throw new CoreException(ErrorType.BAD_REQUEST, "추가할 재고 수량은 0보다 커야 합니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -20,6 +20,7 @@ public class ProductEntity extends BaseEntity {
     private BigDecimal price;
     private int stock;
     private Long brandId;
+    private Integer likeCount = 0;
 
     public ProductEntity(
             final String name,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.product;
 
+import java.math.BigDecimal;
+
 public record ProductInfo(
         Long id,
         String name,
         String description,
-        int price,
+        BigDecimal price,
         int stock,
         Long brandId,
         Long likeCount

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
@@ -9,7 +9,7 @@ public record ProductInfo(
         BigDecimal price,
         int stock,
         Long brandId,
-        Long likeCount
+        int likeCount
 ) {
     public static ProductInfo from(final ProductWithLikeCount productWithLikeCount) {
         return new ProductInfo(
@@ -19,7 +19,19 @@ public record ProductInfo(
                 productWithLikeCount.product().getPrice(),
                 productWithLikeCount.product().getStock(),
                 productWithLikeCount.product().getBrandId(),
-                productWithLikeCount.likeCount()
+                Math.toIntExact(productWithLikeCount.likeCount())
+        );
+    }
+
+    public static  ProductInfo from(final ProductEntity product) {
+        return new ProductInfo(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                product.getStock(),
+                product.getBrandId(),
+                product.getLikeCount()
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -12,7 +12,7 @@ public interface ProductRepository {
 
     List<ProductWithLikeCount> findAllOrderBySortType(String sortType);
 
-    List<ProductWithLikeCount> findAllByBrandId(Long brandId, Pageable pageable);
+    List<ProductWithBrand> findAllByBrandId(Long brandId, Pageable pageable);
 
     List<ProductWithLikeCount> findAllById(List<Long> productIds);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.product;
 
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -9,6 +11,8 @@ public interface ProductRepository {
     ProductWithLikeCount findDetailById(Long id);
 
     List<ProductWithLikeCount> findAllOrderBySortType(String sortType);
+
+    List<ProductWithLikeCount> findAllByBrandId(Long brandId, Pageable pageable);
 
     List<ProductWithLikeCount> findAllById(List<Long> productIds);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -4,6 +4,9 @@ import com.loopers.support.enums.SortType;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,17 +18,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 public class ProductService {
+
     private final ProductRepository productRepository;
 
-    public ProductEntity save(final ProductCommand.Create command) {
-        final ProductEntity product = new ProductEntity(
-                command.name(),
-                command.description(),
-                command.price(),
-                command.stock(),
-                command.brandId()
-        );
 
+    // 저장/수정 시 상세 + 목록 무효화
+    @Caching(evict = {
+            @CacheEvict(value = "productDetail", key = "#result.id", condition = "#result != null"),
+            @CacheEvict(value = "productList", allEntries = true)
+    })
+    public ProductEntity save(final ProductCommand.Create command) {
+        var product = new ProductEntity(
+                command.name(), command.description(),
+                command.price(), command.stock(), command.brandId()
+        );
         return productRepository.save(product);
     }
 
@@ -34,6 +40,10 @@ public class ProductService {
         return products.stream().map(ProductInfo::from).collect(Collectors.toList());
     }
 
+    @Cacheable(
+            value = "productList",
+            key = "'brand:' + #brandId + ':p:' + #pageable.pageNumber + ':s:' + #pageable.pageSize"
+    )
     public List<ProductWithBrand> getProductsByBrandId(Long brandId, Pageable pageable) {
         List<ProductWithBrand> products = productRepository.findAllByBrandId(brandId, pageable);
         if (products.isEmpty()) {
@@ -42,12 +52,11 @@ public class ProductService {
         return products;
     }
 
+    @Cacheable(value = "productDetail", key = "#productId")
     public ProductInfo getProduct(final Long productId) {
-        Optional<ProductWithLikeCount> product = Optional.ofNullable(productRepository.findDetailById(productId));
-        if (product.isEmpty()) {
-            throw new CoreException(ErrorType.NOT_FOUND, "해당 상품이 존재하지 않습니다.");
-        }
-        return ProductInfo.from(product.get());
+        var found = Optional.ofNullable(productRepository.findDetailById(productId))
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 상품이 존재하지 않습니다."));
+        return ProductInfo.from(found);
     }
 
     public List<ProductInfo> getProductsByProductId(List<Long> productIds) {
@@ -58,16 +67,17 @@ public class ProductService {
         return products.stream().map(ProductInfo::from).collect(Collectors.toList());
     }
 
+    // 재고 변경 → 상세 + 목록 무효화
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "productDetail", key = "#command.productId()"),
+            @CacheEvict(value = "productList", allEntries = true)
+    })
     public void consume(ProductCommand.Consume command) {
-        Optional<ProductEntity> product = productRepository.findByIdForUpdate(command.productId());
-
-        if (product.isPresent()) {
-            product.get().decreaseStock(command.quantity().getQuantity());
-            productRepository.save(product.get());
-        } else {
-            throw new CoreException(ErrorType.NOT_FOUND, "해당 상품이 존재하지 않습니다.");
-        }
+        var product = productRepository.findByIdForUpdate(command.productId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 상품이 존재하지 않습니다."));
+        product.decreaseStock(command.quantity().getQuantity());
+        productRepository.save(product);
     }
 
     public List<ProductInfo> getLikedProducts(Long userId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -34,12 +34,12 @@ public class ProductService {
         return products.stream().map(ProductInfo::from).collect(Collectors.toList());
     }
 
-    public List<ProductInfo> getProductsByBrandId(Long brandId, Pageable pageable) {
-        List<ProductWithLikeCount> products = productRepository.findAllByBrandId(brandId, pageable);
+    public List<ProductWithBrand> getProductsByBrandId(Long brandId, Pageable pageable) {
+        List<ProductWithBrand> products = productRepository.findAllByBrandId(brandId, pageable);
         if (products.isEmpty()) {
             throw new CoreException(ErrorType.NOT_FOUND, "해당 브랜드의 상품이 존재하지 않습니다.");
         }
-        return products.stream().map(ProductInfo::from).collect(Collectors.toList());
+        return products;
     }
 
     public ProductInfo getProduct(final Long productId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductWithBrand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductWithBrand.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.brand.BrandEntity;
+
+public record ProductWithBrand(
+        ProductEntity product,
+        BrandEntity brand
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/CacheConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/CacheConfig.java
@@ -1,0 +1,41 @@
+package com.loopers.infrastructure.cache;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+
+        // 기본 캐시 설정 (null 캐싱 방지 + 직렬화 설정)
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new GenericJackson2JsonRedisSerializer())
+                );
+
+        // 캐시별 TTL 지정
+        Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+        cacheConfigs.put("productList", defaultConfig.entryTtl(Duration.ofSeconds(90))); // 1분 30초
+        cacheConfigs.put("productDetail", defaultConfig.entryTtl(Duration.ZERO)); // 무제한, @CacheEvict로 무효화
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigs)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -3,6 +3,7 @@ package com.loopers.infrastructure.product;
 import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.product.ProductWithLikeCount;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -70,4 +71,16 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
                 GROUP BY p
             """)
     List<ProductWithLikeCount> findLikedProductsByUserId(@Param("userId") Long userId);
+
+    @Query("""
+                SELECT new com.loopers.domain.product.ProductWithLikeCount(
+                    p,
+                    COUNT(l.id)
+                )
+                FROM ProductEntity p
+                LEFT JOIN LikeEntity l ON l.productId = p.id
+                WHERE p.brandId = :brandId
+                GROUP BY p
+            """)
+    List<ProductWithLikeCount> findAllByBrandId(@Param("brandId") Long brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,6 +1,7 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductWithBrand;
 import com.loopers.domain.product.ProductWithLikeCount;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
@@ -73,14 +74,13 @@ public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long>
     List<ProductWithLikeCount> findLikedProductsByUserId(@Param("userId") Long userId);
 
     @Query("""
-                SELECT new com.loopers.domain.product.ProductWithLikeCount(
+                SELECT new com.loopers.domain.product.ProductWithBrand(
                     p,
-                    COUNT(l.id)
+                    b
                 )
                 FROM ProductEntity p
-                LEFT JOIN LikeEntity l ON l.productId = p.id
-                WHERE p.brandId = :brandId
-                GROUP BY p
+                JOIN BrandEntity b ON p.brandId = b.id
+                WHERE b.id = :brandId
             """)
-    List<ProductWithLikeCount> findAllByBrandId(@Param("brandId") Long brandId, Pageable pageable);
+    List<ProductWithBrand> findAllByBrandId(@Param("brandId") Long brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductWithLikeCount;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -22,6 +23,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public List<ProductWithLikeCount> findAllOrderBySortType(String sortType) {
         return productJpaRepository.findAllOrderBySortType(sortType);
+    }
+
+    @Override
+    public List<ProductWithLikeCount> findAllByBrandId(Long brandId, Pageable pageable) {
+        return productJpaRepository.findAllByBrandId(brandId, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductWithBrand;
 import com.loopers.domain.product.ProductWithLikeCount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +27,7 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public List<ProductWithLikeCount> findAllByBrandId(Long brandId, Pageable pageable) {
+    public List<ProductWithBrand> findAllByBrandId(Long brandId, Pageable pageable) {
         return productJpaRepository.findAllByBrandId(brandId, pageable);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -4,9 +4,11 @@ import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.support.error.CoreException;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import java.math.BigDecimal;
+
 @Tag(name = "User V1 API", description = "회원가입 및 사용자 정보 조회 API")
 public interface PointV1ApiSpec {
     ApiResponse<PointV1Dto.GetResponse> getUserPoint(String userId) throws CoreException;
 
-    ApiResponse<PointV1Dto.GetResponse> charge(String userId, Long amount) throws CoreException;
+    ApiResponse<PointV1Dto.GetResponse> charge(String userId, BigDecimal amount) throws CoreException;
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -7,6 +7,8 @@ import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.support.error.CoreException;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
+
 @RestController
 @RequestMapping("/api/v1/points")
 public class PointV1Controller implements PointV1ApiSpec {
@@ -32,7 +34,7 @@ public class PointV1Controller implements PointV1ApiSpec {
 
     @PostMapping("/charge")
     @Override
-    public ApiResponse<PointV1Dto.GetResponse> charge(@RequestHeader(value = "X-USER-ID", required = true) String loginId, @RequestBody Long amount) throws CoreException {
+    public ApiResponse<PointV1Dto.GetResponse> charge(@RequestHeader(value = "X-USER-ID", required = true) String loginId, @RequestBody BigDecimal amount) throws CoreException {
 
         PointV1Dto.GetResponse response = PointV1Dto.GetResponse.from(
                 pointFacade.charge(new PointCriteria.Charge(loginId, amount))

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -4,12 +4,14 @@ import com.loopers.application.point.PointCriteria;
 import com.loopers.application.point.PointResult;
 import jakarta.validation.constraints.NotNull;
 
+import java.math.BigDecimal;
+
 public class PointV1Dto {
 
     public record ChargeRequest(
             @NotNull
             String loginId,
-            Long amount
+            BigDecimal amount
     ) {
         public PointCriteria.Charge  toCriteria(PointV1Dto.ChargeRequest request) {
             return new PointCriteria.Charge(request.loginId(), request.amount());
@@ -19,7 +21,7 @@ public class PointV1Dto {
     public record GetResponse(
             Long id,
             String loginId,
-            Long amount
+            BigDecimal amount
     ) {
         public static PointV1Dto.GetResponse from(PointResult info) {
             return new PointV1Dto.GetResponse(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -1,0 +1,22 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Tag(name = "Product V1 API", description = "상품 관련 API")
+public interface ProductV1ApiSpec {
+    @Operation(
+            summary = "상품 목록 조회",
+            description = "상품 목록을 조회합니다."
+    )
+    ApiResponse<List<ProductV1Dto.GetProductsResponse>> getProductsByBrandId(
+            Long brandId,
+            @Schema(name = "페이징 정보", description = "페이지네이션을 위한 정보입니다. 기본값은 20개씩 내림차순 정렬입니다.")
+            Pageable pageable
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/api/v1/products")
+public class ProductV1Controller implements ProductV1ApiSpec{
+    private final ProductFacade productFacade;
+
+    public ProductV1Controller(ProductFacade productFacade) {
+        this.productFacade = productFacade;
+    }
+
+    @Override
+    public ApiResponse<List<ProductV1Dto.GetProductsResponse>> getProductsByBrandId(
+            Long brandId,
+            @PageableDefault(size = 20, sort = {"likeCount", "id", "price"}, direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        var query = ProductV1Dto.GetProductsRequest.toQuery(brandId, pageable);
+        var response = ProductV1Dto.GetProductsResponse.from(productFacade.getProductsByBrandId(query));
+
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -5,12 +5,14 @@ import com.loopers.interfaces.api.ApiResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequestMapping("/api/v1/products")
 public class ProductV1Controller implements ProductV1ApiSpec{
     private final ProductFacade productFacade;
@@ -20,8 +22,9 @@ public class ProductV1Controller implements ProductV1ApiSpec{
     }
 
     @Override
+    @GetMapping("")
     public ApiResponse<List<ProductV1Dto.GetProductsResponse>> getProductsByBrandId(
-            Long brandId,
+            @RequestParam Long brandId,
             @PageableDefault(size = 20, sort = {"likeCount", "id", "price"}, direction = Sort.Direction.DESC)
             Pageable pageable
     ) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,0 +1,57 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductQuery;
+import com.loopers.application.product.ProductResult;
+import com.loopers.domain.product.ProductEntity;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+public class ProductV1Dto {
+    public record GetProductsRequest(
+            Long brandId,
+            Pageable pageable
+    ) {
+        public static ProductQuery.GetProductsByBrandId toQuery(
+                final Long brandId,
+                final Pageable pageable
+        ) {
+            return new ProductQuery.GetProductsByBrandId(
+                    brandId,
+                    pageable
+            );
+        }
+    }
+
+    public record GetProductsResponse(
+            Long id,
+            String name,
+            String description,
+            BigDecimal price,
+            int stock,
+            Long likeCount,
+            Long brandId,
+            String brandName,
+            String brandDescription
+    ) {
+        public static List<GetProductsResponse> from(final List<Optional<ProductResult>> productResult) {
+            return productResult.stream()
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(product -> new GetProductsResponse(
+                            product.id(),
+                            product.name(),
+                            product.description(),
+                            product.price(),
+                            product.stock(),
+                            product.likeCount(),
+                            product.brandId(),
+                            product.brandName(),
+                            product.brandDescription()
+                    ))
+                    .toList();
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -3,6 +3,7 @@ package com.loopers.interfaces.api.product;
 import com.loopers.application.product.ProductQuery;
 import com.loopers.application.product.ProductResult;
 import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductWithBrand;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
@@ -31,25 +32,23 @@ public class ProductV1Dto {
             String description,
             BigDecimal price,
             int stock,
-            Long likeCount,
+            int likeCount,
             Long brandId,
             String brandName,
             String brandDescription
     ) {
-        public static List<GetProductsResponse> from(final List<Optional<ProductResult>> productResult) {
+        public static List<GetProductsResponse> from(final List<ProductWithBrand> productResult) {
             return productResult.stream()
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .map(product -> new GetProductsResponse(
-                            product.id(),
-                            product.name(),
-                            product.description(),
-                            product.price(),
-                            product.stock(),
-                            product.likeCount(),
-                            product.brandId(),
-                            product.brandName(),
-                            product.brandDescription()
+                    .map(productWithBrand -> new GetProductsResponse(
+                            productWithBrand.product().getId(),
+                            productWithBrand.product().getName(),
+                            productWithBrand.product().getDescription(),
+                            productWithBrand.product().getPrice(),
+                            productWithBrand.product().getStock(),
+                            Math.toIntExact(productWithBrand.product().getLikeCount()),
+                            productWithBrand.brand().getId(),
+                            productWithBrand.brand().getName(),
+                            productWithBrand.brand().getDescription()
                     ))
                     .toList();
         }

--- a/apps/commerce-api/src/main/java/com/loopers/support/seed/LocalJpaSeedService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/seed/LocalJpaSeedService.java
@@ -1,0 +1,89 @@
+package com.loopers.support.seed;
+
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.brand.BrandEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import net.datafaker.Faker;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+@Transactional // <-- 전체 시드 작업을 하나의 트랜잭션으로
+public class LocalJpaSeedService {
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    @Value("${seed.enabled:true}")       private boolean enabled;
+    @Value("${seed.drop-and-reseed:true}") private boolean dropAndReseed;
+
+    @Value("${seed.brands:100}")        private int brands;
+    @Value("${seed.products:100000}")   private int products;
+    @Value("${seed.batch-size:1000}")   private int batchSize;
+
+    private final Faker faker = new Faker(new Locale("ko", "KR"));
+
+    public void seedAll() {
+        if (!enabled) return;
+
+        if (dropAndReseed) {
+            // FK 고려: product -> brand 순서로 비우기
+            exec("SET FOREIGN_KEY_CHECKS = 0");
+            exec("TRUNCATE TABLE product");
+            exec("TRUNCATE TABLE brand");
+            exec("SET FOREIGN_KEY_CHECKS = 1");
+        }
+
+        if (count("brand") == 0) insertBrands();
+        if (count("product") == 0) insertProducts();
+    }
+
+    private long count(String table) {
+        return ((Number) em.createNativeQuery("SELECT COUNT(*) FROM " + table)
+                .getSingleResult()).longValue();
+    }
+
+    private void exec(String sql) {
+        em.createNativeQuery(sql).executeUpdate();
+    }
+
+    private void insertBrands() {
+        for (int i = 1; i <= brands; i++) {
+            var brand = new BrandEntity(
+                    faker.company().name(),
+                    faker.lorem().sentence()
+            );
+            em.persist(brand);
+            if (i % batchSize == 0) { em.flush(); em.clear(); }
+        }
+    }
+
+    private void insertProducts() {
+        for (int i = 1; i <= products; i++) {
+            var price = BigDecimal.valueOf(1000 + ThreadLocalRandom.current().nextInt(100_000 - 1000 + 1));
+            var stock = ThreadLocalRandom.current().nextInt(0, 101);
+            var brandId = (long) ThreadLocalRandom.current().nextInt(1, brands + 1);
+            var likes = ThreadLocalRandom.current().nextInt(1, 2001); // 1~2000
+
+            var p = ProductEntity.create(
+                    faker.commerce().productName(),
+                    faker.lorem().paragraph(),
+                    price,
+                    stock,
+                    brandId,
+                    likes
+            );
+
+            em.persist(p);
+            if (i % batchSize == 0) { em.flush(); em.clear(); }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/seed/LocalJpaSeedService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/seed/LocalJpaSeedService.java
@@ -22,8 +22,8 @@ public class LocalJpaSeedService {
     @PersistenceContext
     private final EntityManager em;
 
-    @Value("${seed.enabled:true}")       private boolean enabled;
-    @Value("${seed.drop-and-reseed:true}") private boolean dropAndReseed;
+    @Value("${seed.enabled:false}")       private boolean enabled;
+    @Value("${seed.drop-and-reseed:false}") private boolean dropAndReseed;
 
     @Value("${seed.brands:100}")        private int brands;
     @Value("${seed.products:100000}")   private int products;

--- a/apps/commerce-api/src/main/java/com/loopers/support/seed/LocalJpaSeeder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/seed/LocalJpaSeeder.java
@@ -1,0 +1,19 @@
+package com.loopers.support.seed;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.boot.CommandLineRunner;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class LocalJpaSeeder implements CommandLineRunner {
+
+    private final LocalJpaSeedService seedService;
+
+    @Override
+    public void run(String... args) {
+        seedService.seedAll(); // 프록시 통해 @Transactional 적용됨
+    }
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
   config:
     import:
       - jpa.yml
+      - redis.yml
       - logging.yml
       - monitoring.yml
 

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -55,3 +55,11 @@ spring:
 springdoc:
   api-docs:
     enabled: false
+
+---
+seed:
+  enabled: true
+  drop-and-reseed: true   # 한번 싹 비우고 다시 넣고 싶을 때만 true
+  brands: 100
+  products: 100000
+  batch-size: 1000

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -227,13 +228,13 @@ public class CouponServiceIntegrationTest {
             Coupon coupon = couponService.createCoupon(createCommand);
 
             // act
-            int discountedPrice = couponService.calculateDiscountPrice(
-                    List.of(1000),
+            BigDecimal discountedPrice = couponService.calculateDiscountPrice(
+                    List.of(BigDecimal.valueOf(1000)),
                     1L
             );
 
             // assert
-            assertThat(discountedPrice).isEqualTo(0);
+            assertThat(discountedPrice).isEqualByComparingTo(BigDecimal.ZERO);
         }
 
         @DisplayName("만료된 쿠폰이 주어지면, 예외를 발생시킨다.")
@@ -252,7 +253,7 @@ public class CouponServiceIntegrationTest {
 
             // act & assert
             CoreException ex = assertThrows(CoreException.class, () ->
-                    couponService.calculateDiscountPrice(List.of(5000), coupon.getId())
+                    couponService.calculateDiscountPrice(List.of(BigDecimal.valueOf(5000)), coupon.getId())
             );
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
             assertThat(ex.getMessage()).isEqualTo("사용기한이 지난 쿠폰입니다.");
@@ -292,7 +293,7 @@ public class CouponServiceIntegrationTest {
                         ready.countDown();
                         start.await();
                         try {
-                            couponService.calculateDiscountPrice(List.of(5000), couponId);
+                            couponService.calculateDiscountPrice(List.of(BigDecimal.valueOf(5000)), couponId);
                             success.incrementAndGet();
                         } catch (Exception e) {
                             fail.incrementAndGet();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -281,7 +281,7 @@ public class CouponServiceIntegrationTest {
             ExecutorService pool = Executors.newFixedThreadPool(threads);
             CountDownLatch ready = new CountDownLatch(threads);
             CountDownLatch start = new CountDownLatch(1);
-            CountDownLatch done = new CountDownLatch(threads);
+            CountDownLatch latch = new CountDownLatch(threads);
             AtomicInteger success = new AtomicInteger(0);
             AtomicInteger fail = new AtomicInteger(0);
             CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
@@ -302,7 +302,7 @@ public class CouponServiceIntegrationTest {
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
                     } finally {
-                        done.countDown();
+                        latch.countDown();
                     }
                 });
             }
@@ -311,7 +311,7 @@ public class CouponServiceIntegrationTest {
                 throw new IllegalStateException("Threads not ready in time");
             }
             start.countDown();
-            done.await(15, TimeUnit.SECONDS);
+            latch.await(15, TimeUnit.SECONDS);
             pool.shutdownNow();
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -16,11 +16,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -116,84 +119,72 @@ public class LikeServiceIntegrationTest {
     @Test
     @DisplayName("동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.")
     void likeAndUnlikeByMultipleUsers() throws Exception {
-        // arrange: 유저 10명 생성/저장
-        List<UserEntity> users = List.of(
-                new UserEntity(new LoginId("user1"), "User One",  new Email("user1@loopers.com"), new Birth("2000-01-01"), Gender.F),
-                new UserEntity(new LoginId("user2"), "User Two",  new Email("user2@loopers.com"), new Birth("2000-01-02"), Gender.F),
-                new UserEntity(new LoginId("user3"), "User Three",new Email("user3@loopers.com"), new Birth("2000-01-03"), Gender.F),
-                new UserEntity(new LoginId("user4"), "User Four", new Email("user4@loopers.com"), new Birth("2000-01-04"), Gender.F),
-                new UserEntity(new LoginId("user5"), "User Five", new Email("user5@loopers.com"), new Birth("2000-01-05"), Gender.F),
-                new UserEntity(new LoginId("user6"), "User Six",  new Email("user6@loopers.com"), new Birth("2000-01-06"), Gender.F),
-                new UserEntity(new LoginId("user7"), "User Seven",new Email("user7@loopers.com"), new Birth("2000-01-07"), Gender.F),
-                new UserEntity(new LoginId("user8"), "User Eight",new Email("user8@loopers.com"), new Birth("2000-01-08"), Gender.F),
-                new UserEntity(new LoginId("user9"), "User Nine", new Email("user9@loopers.com"), new Birth("2000-01-09"), Gender.F),
-                new UserEntity(new LoginId("user10"),"User Ten",  new Email("user10@loopers.com"),new Birth("2000-01-10"), Gender.F)
-        );
-        List<UserEntity> savedUsers = users.stream()
-                .map(userRepository::save)
-                .toList();
+        // arrange
+        // arrange
+        List<UserEntity> savedUsers = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            UserEntity userEntity = new UserEntity(
+                    new LoginId("user" + i),
+                    "User " + (i == 10 ? "Ten" : " " + i),
+                    new Email("user" + i + "@loopers.com"),
+                    new Birth("2000-01-" + String.format("%02d", i)),
+                    Gender.F
+            );
+            savedUsers.add(userRepository.save(userEntity));
+        }
 
-        // 테스트용 상품 조회 (기존 테스트 스타일 유지)
         ProductEntity savedProduct = productRepository.findAllById(List.of(1L)).get(0).product();
         Long productId = savedProduct.getId();
 
-        // act 1: 10명이 동시에 좋아요
-        int threads1 = savedUsers.size();
-        ExecutorService pool1 = Executors.newFixedThreadPool(threads1);
-        CountDownLatch ready1 = new CountDownLatch(threads1);
-        CountDownLatch start1 = new CountDownLatch(1);
-        CountDownLatch done1 = new CountDownLatch(threads1);
+        // act 1: 좋아요 10명 동시
+        runConcurrent(savedUsers.size(),
+                userIdx -> likeService.like(new LikeCommand.Like(savedUsers.get(userIdx).getId(), productId))
+        );
 
-        for (UserEntity u : savedUsers) {
-            pool1.submit(() -> {
-                try {
-                    ready1.countDown();
-                    start1.await();
-                    likeService.like(new LikeCommand.Like(u.getId(), productId));
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    done1.countDown();
-                }
-            });
+        // then 1
+        assertThat(productRepository.findDetailById(productId).likeCount()).isEqualTo(10);
+
+        // act 2: 싫어요 3명 동시
+        runConcurrent(3,
+                userIdx -> likeService.unlike(new LikeCommand.Like(savedUsers.get(userIdx).getId(), productId))
+        );
+
+        // then 2
+        assertThat(productRepository.findDetailById(productId).likeCount()).isEqualTo(7);
+    }
+
+    /**
+     * 지정된 개수의 쓰레드를 동시에 시작시켜 작업을 실행한다.
+     * @param threads 쓰레드 수
+     * @param task    인덱스를 인자로 받는 작업
+     */
+    private void runConcurrent(int threads, IntConsumer task) throws InterruptedException {
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch readyLatch = new CountDownLatch(threads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch  = new CountDownLatch(threads);
+
+        IntStream.range(0, threads).forEach(i ->
+                pool.submit(() -> {
+                    try {
+                        readyLatch.countDown();
+                        startLatch.await();
+                        task.accept(i);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                })
+        );
+
+        if (!readyLatch.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Threads not ready in time");
         }
-        if (!ready1.await(5, TimeUnit.SECONDS)) throw new IllegalStateException("Phase1 threads not ready");
-        start1.countDown();
-        done1.await(10, TimeUnit.SECONDS);
-        pool1.shutdownNow();
-
-        // then 1: 좋아요 수 = 10
-        ProductWithLikeCount afterLike = productRepository.findDetailById(productId);
-        assertThat(afterLike.likeCount()).isEqualTo(10);
-
-        // act 2: 3명이 동시에 싫어요(취소) — user1, user2, user3
-        List<UserEntity> toUnlike = savedUsers.subList(0, 3);
-        int threads2 = toUnlike.size();
-        ExecutorService pool2 = Executors.newFixedThreadPool(threads2);
-        CountDownLatch ready2 = new CountDownLatch(threads2);
-        CountDownLatch start2 = new CountDownLatch(1);
-        CountDownLatch done2 = new CountDownLatch(threads2);
-
-        for (UserEntity u : toUnlike) {
-            pool2.submit(() -> {
-                try {
-                    ready2.countDown();
-                    start2.await();
-                    likeService.unlike(new LikeCommand.Like(u.getId(), productId));
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    done2.countDown();
-                }
-            });
+        startLatch.countDown();
+        if (!doneLatch.await(10, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Tasks did not finish in time");
         }
-        if (!ready2.await(5, TimeUnit.SECONDS)) throw new IllegalStateException("Phase2 threads not ready");
-        start2.countDown();
-        done2.await(10, TimeUnit.SECONDS);
-        pool2.shutdownNow();
-
-        // then 2: 최종 좋아요 수 = 10 - 3 = 7
-        ProductWithLikeCount afterUnlike = productRepository.findDetailById(productId);
-        assertThat(afterUnlike.likeCount()).isEqualTo(7);
+        pool.shutdownNow();
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -62,7 +63,7 @@ public class LikeServiceIntegrationTest {
         productRepository.save(new ProductEntity(
                         "아디다스 운동화",
                         "운동할 때 신는 운동화임",
-                        10000,
+                        BigDecimal.valueOf(10000),
                         10,
                         savedBrand.getId()
                 )

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.ArrayList;
@@ -95,14 +96,14 @@ public class OrderServiceIntegrationTest {
         var product1 = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                10000,
+                BigDecimal.valueOf(10000),
                 10,
                 1L
         );
         var product2 = new ProductCommand.Create(
                 "운동화",
                 "그냥 운동할 때 신는 거임",
-                20000,
+                BigDecimal.valueOf(20000),
                 10,
                 1L
         );
@@ -111,8 +112,8 @@ public class OrderServiceIntegrationTest {
 
         var orderCommand = new OrderCommand.Order(
                 1L,
-                List.of(new OrderCommand.OrderItem(1L, new Quantity(1), 10000),
-                        new OrderCommand.OrderItem(2L, new Quantity(2), 20000))
+                List.of(new OrderCommand.OrderItem(1L, new Quantity(1), BigDecimal.valueOf(10000)),
+                        new OrderCommand.OrderItem(2L, new Quantity(2),  BigDecimal.valueOf(20000)))
         );
 
         // act
@@ -126,7 +127,7 @@ public class OrderServiceIntegrationTest {
                 () -> assertThat(orderInfo.orderItems().size()).isEqualTo(2),
                 () -> assertThat(orderInfo.orderItems().get(0).getProductId()).isEqualTo(1L),
                 () -> assertThat(orderInfo.orderItems().get(0).getQuantity().getQuantity()).isEqualTo(1),
-                () -> assertThat(orderInfo.totalPrice()).isEqualTo(50000) // 10000 * 1 + 20000 * 2
+                () -> assertThat(orderInfo.totalPrice()).isEqualTo(BigDecimal.valueOf(50000)) // 10000 * 1 + 20000 * 2
         );
     }
 
@@ -144,7 +145,7 @@ public class OrderServiceIntegrationTest {
 
         pointService.initPoint(new PointCommand.Init(
                 "loopers123",
-                30000L
+                BigDecimal.valueOf(30000)
         ));
 
 
@@ -152,21 +153,21 @@ public class OrderServiceIntegrationTest {
         var productCommand = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                1000,
+                BigDecimal.valueOf(10000),
                 10,
                 brand.getId()
         );
 
         productService.save(productCommand);
 
-        int disCountedTotalPrice = 5000;  // 할인된 금액
+        BigDecimal disCountedTotalPrice = BigDecimal.valueOf(5000);  // 할인된 금액
 
         // act
-        pointService.use(new PointCommand.Use(userInfo.loginId().getLoginId(), (long) disCountedTotalPrice));
+        pointService.use(new PointCommand.Use(userInfo.loginId().getLoginId(), disCountedTotalPrice));
 
         // assert
         assertThat(pointRepository.findByLoginId(new LoginId("loopers123")).get().getAmount())
-                .isEqualTo(25000L); // 30000 - 5000 (5 * 10000)
+                .isEqualByComparingTo(BigDecimal.valueOf(25000)); // 30000 - 5000 (5 * 10000)
     }
 
     @Test
@@ -183,7 +184,7 @@ public class OrderServiceIntegrationTest {
 
         pointService.initPoint(new PointCommand.Init(
                 "loopers123",
-                30000L
+                BigDecimal.valueOf(30000)
         ));
 
 
@@ -191,7 +192,7 @@ public class OrderServiceIntegrationTest {
         var productCommand = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                1000,
+                BigDecimal.valueOf(1000),
                 10,
                 brand.getId()
         );
@@ -199,11 +200,11 @@ public class OrderServiceIntegrationTest {
         productService.save(productCommand);
 
         // act
-        int disCountedTotalPrice = 35000;  // 35개 주문
+        BigDecimal disCountedTotalPrice = BigDecimal.valueOf(35000);  // 35개 주문
 
         // act & assert
         assertThrows(IllegalArgumentException.class, () -> {
-            pointService.use(new PointCommand.Use(userInfo.loginId().getLoginId(), (long) disCountedTotalPrice));
+            pointService.use(new PointCommand.Use(userInfo.loginId().getLoginId(), disCountedTotalPrice));
         });
     }
 
@@ -221,14 +222,14 @@ public class OrderServiceIntegrationTest {
 
         pointService.initPoint(new PointCommand.Init(
                 "loopers123",
-                30000L
+                BigDecimal.valueOf(30000)
         ));
 
         BrandEntity brand = brandJpaRepository.save(new BrandEntity("아디다스", "아디다스 입니다."));
         var productCommand = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                10000,
+                BigDecimal.valueOf(10000),
                 10,
                 brand.getId()
         );
@@ -268,14 +269,14 @@ public class OrderServiceIntegrationTest {
 
         pointService.initPoint(new PointCommand.Init(
                 "loopers123",
-                30000L
+                BigDecimal.valueOf(30000)
         ));
 
         BrandEntity brand = brandJpaRepository.save(new BrandEntity("아디다스", "아디다스 입니다."));
         var productCommand = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                10000,
+                BigDecimal.valueOf(10000),
                 0,
                 brand.getId()
         );
@@ -313,14 +314,14 @@ public class OrderServiceIntegrationTest {
 
         pointService.initPoint(new PointCommand.Init(
                 "loopers123",
-                30000L
+                BigDecimal.valueOf(30000)
         ));
 
         BrandEntity brand = brandJpaRepository.save(new BrandEntity("아디다스", "아디다스 입니다."));
         var productCommand = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                10000,
+                BigDecimal.valueOf(10000),
                 10,   // 초기 재고
                 brand.getId()
         );
@@ -380,11 +381,11 @@ public class OrderServiceIntegrationTest {
         UserInfo user = userService.signUp(new UserCommand.SignUp(
                 "loopers123", "hyun", "loopers@naver.com", "1990-01-01", Gender.F
         ));
-        pointService.initPoint(new PointCommand.Init(user.loginId().getLoginId(), 30000L));
-        long beforePoint = pointRepository.findByLoginId(new LoginId("loopers123")).orElseThrow().getAmount();
+        pointService.initPoint(new PointCommand.Init(user.loginId().getLoginId(), BigDecimal.valueOf(10000L)));
+        BigDecimal beforePoint = pointRepository.findByLoginId(new LoginId("loopers123")).orElseThrow().getAmount();
 
         BrandEntity brand = brandJpaRepository.save(new BrandEntity("아디다스", "아디다스 입니다."));
-        var p = new ProductCommand.Create("운동복 세트", "그냥 운동", 10000, 5, brand.getId());
+        var p = new ProductCommand.Create("운동복 세트", "그냥 운동", BigDecimal.valueOf(10000), 5, brand.getId());
         productService.save(p);
         int beforeStock = productRepository.findById(1L).orElseThrow().getStock();
 
@@ -413,7 +414,7 @@ public class OrderServiceIntegrationTest {
             productService.consume(new ProductCommand.Consume(1L, new Quantity(11)));
         });
 
-        long afterPoint = pointRepository.findByLoginId(new LoginId("loopers123")).orElseThrow().getAmount();
+        BigDecimal afterPoint = pointRepository.findByLoginId(new LoginId("loopers123")).orElseThrow().getAmount();
         assertThat(afterPoint).isEqualTo(beforePoint);
 
         int afterStock = productRepository.findById(1L).orElseThrow().getStock();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -196,7 +196,7 @@ public class PointServiceIntegrationTest {
 
         ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(threads);
         var start = new CountDownLatch(1);
-        CountDownLatch done = new CountDownLatch(threads);
+        CountDownLatch latch = new CountDownLatch(threads);
         List<Throwable> errors = Collections.synchronizedList(new java.util.ArrayList<>());
 
         for (int i = 0; i < threads; i++) {
@@ -207,13 +207,13 @@ public class PointServiceIntegrationTest {
                 } catch (Throwable t) {
                     errors.add(t);
                 } finally {
-                    done.countDown();
+                    latch.countDown();
                 }
             });
         }
 
         start.countDown();
-        done.await();
+        latch.await();
         executor.shutdown();
 
         assertThat(errors.isEmpty()).isTrue();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -73,7 +74,7 @@ public class PointServiceIntegrationTest {
         //assert
         assertAll(
                 () -> assertThat(pointInfo.loginId().getLoginId()).isEqualTo("loopers123"),
-                () -> assertThat(pointInfo.amount()).isEqualTo(100)
+                () -> assertThat(pointInfo.amount()).isEqualByComparingTo(BigDecimal.valueOf(100))
         );
     }
 
@@ -113,7 +114,7 @@ public class PointServiceIntegrationTest {
 
         // act
         CoreException exception = assertThrows(CoreException.class, () -> {
-            pointService.charge(new PointCommand.Charge("roopers123", 100L));
+            pointService.charge(new PointCommand.Charge("roopers123", BigDecimal.valueOf(100)));
         });
 
         // assert
@@ -133,17 +134,17 @@ public class PointServiceIntegrationTest {
                         Gender.M
                 ));
 
-        pointService.initPoint(new PointCommand.Init("loopers123", 100L));
+        pointService.initPoint(new PointCommand.Init("loopers123", BigDecimal.valueOf(100)));
 
         // act
-        pointService.charge(new PointCommand.Charge("loopers123", 100L));
+        pointService.charge(new PointCommand.Charge("loopers123", BigDecimal.valueOf(100)));
 
         // assert
         PointInfo pointInfo = pointService.get("loopers123");
         assertAll(
                 () -> assertThat(pointInfo).isNotNull(),
                 () -> assertThat(pointInfo.loginId().getLoginId()).isEqualTo("loopers123"),
-                () -> assertThat(pointInfo.amount()).isEqualTo(200L) // 초기 100 + 충전 100
+                () -> assertThat(pointInfo.amount()).isEqualByComparingTo(BigDecimal.valueOf(200L)) // 초기 100 + 충전 100
         );
     }
 
@@ -160,17 +161,17 @@ public class PointServiceIntegrationTest {
                         Gender.M
                 ));
 
-        pointService.initPoint(new PointCommand.Init("loopers123", 100L));
+        pointService.initPoint(new PointCommand.Init("loopers123", BigDecimal.valueOf(100)));
 
         // act
-        pointService.use(new PointCommand.Use("loopers123", 50L));
+        pointService.use(new PointCommand.Use("loopers123", BigDecimal.valueOf(50)));
 
         // assert
         PointInfo pointInfo = pointService.get("loopers123");
         assertAll(
                 () -> assertThat(pointInfo).isNotNull(),
                 () -> assertThat(pointInfo.loginId().getLoginId()).isEqualTo("loopers123"),
-                () -> assertThat(pointInfo.amount()).isEqualTo(50L) // 초기 100 - 사용 50
+                () -> assertThat(pointInfo.amount()).isEqualByComparingTo(BigDecimal.valueOf(50L)) // 초기 100 - 사용 50
         );
     }
 
@@ -188,10 +189,10 @@ public class PointServiceIntegrationTest {
                         Gender.M
                 ));
 
-        pointService.initPoint(new PointCommand.Init("loopers123", 500L));
+        pointService.initPoint(new PointCommand.Init("loopers123", BigDecimal.valueOf(500)));
 
         int threads = 10;
-        long usePerOrder = 50L;
+        BigDecimal usePerOrder = BigDecimal.valueOf(50);
 
         ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(threads);
         var start = new CountDownLatch(1);
@@ -221,7 +222,7 @@ public class PointServiceIntegrationTest {
         assertAll(
                 () -> assertThat(pointInfo).isNotNull(),
                 () -> assertThat(pointInfo.loginId().getLoginId()).isEqualTo("loopers123"),
-                () -> assertThat(pointInfo.amount()).isEqualTo(0L)
+                () -> assertThat(pointInfo.amount()).isEqualByComparingTo(BigDecimal.ZERO)
         );
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductFacadeTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,8 +42,8 @@ public class ProductFacadeTest {
     @BeforeEach
     void setUp() {
         brandRepository.save(new BrandEntity("브랜드1", "브랜드 설명"));
-        productRepository.save(new ProductEntity("상품1", "설명1", 5000, 5, 1L));
-        productRepository.save(new ProductEntity("상품2", "설명2", 10000, 10, 1L));
+        productRepository.save(new ProductEntity("상품1", "설명1", BigDecimal.valueOf(5000), 5, 1L));
+        productRepository.save(new ProductEntity("상품2", "설명2", BigDecimal.valueOf(10000), 10, 1L));
     }
 
     @AfterEach

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -67,7 +68,7 @@ public class ProductServiceIntegrationTest {
         var product1 = new ProductCommand.Create(
                 "운동복 세트",
                 "그냥 운동할 때 입는 거임",
-                10000,
+                BigDecimal.valueOf(10000),
                 10,
                 brand.getId()
         );
@@ -101,14 +102,14 @@ public class ProductServiceIntegrationTest {
         var product1 = new ProductEntity(
                 "쫄쫄이 티셔츠",
                 "그냥 운동할 때 입는 거임",
-                1000,
+                BigDecimal.valueOf(1000),
                 10,
                 brand.getId()
         );
         var product2 = new ProductEntity(
                 "피마이너스원 콜라보 에어포스",
                 "제일 비싼 지디 콜라보 한정판 신발임",
-                5000,
+                BigDecimal.valueOf(5000),
                 20,
                 brand.getId()
         );
@@ -116,7 +117,7 @@ public class ProductServiceIntegrationTest {
         var product3 = new ProductEntity(
                 "머큐리얼 베이퍼",
                 "적당히 비싼 축구화임",
-                4000,
+                BigDecimal.valueOf(4000),
                 20,
                 brand.getId()
         );
@@ -157,7 +158,7 @@ public class ProductServiceIntegrationTest {
         ProductEntity product = new ProductEntity(
                 "운동화",
                 "편한 운동화",
-                30000,
+                BigDecimal.valueOf(30000),
                 5,
                 brand.getId()
         );
@@ -170,7 +171,7 @@ public class ProductServiceIntegrationTest {
         assertAll(
                 () -> assertThat(productInfo.name()).isEqualTo("운동화"),
                 () -> assertThat(productInfo.description()).isEqualTo("편한 운동화"),
-                () -> assertThat(productInfo.price()).isEqualTo(30000),
+                () -> assertThat(productInfo.price()).isEqualTo(BigDecimal.valueOf(30000)),
                 () -> assertThat(productInfo.stock()).isEqualTo(5),
                 () -> assertThat(productInfo.likeCount()).isEqualTo(0) // 초기 좋아요 수는 0
         );
@@ -181,9 +182,9 @@ public class ProductServiceIntegrationTest {
     void findProductsByProductIds() {
         // arrange
         BrandEntity brand = brandJpaRepository.save(new BrandEntity("아디다스", "아디다스 입니다."));
-        ProductEntity product1 = new ProductEntity("운동화1", "설명1", 10000, 10, brand.getId());
-        ProductEntity product2 = new ProductEntity("운동화2", "설명2", 20000, 20, brand.getId());
-        ProductEntity product3 = new ProductEntity("운동화3", "설명3", 30000, 30, brand.getId());
+        ProductEntity product1 = new ProductEntity("운동화1", "설명1", BigDecimal.valueOf(10000), 10, brand.getId());
+        ProductEntity product2 = new ProductEntity("운동화2", "설명2", BigDecimal.valueOf(20000), 20, brand.getId());
+        ProductEntity product3 = new ProductEntity("운동화3", "설명3", BigDecimal.valueOf(30000), 30, brand.getId());
 
         ProductEntity savedProduct1 = productRepository.save(product1);
         ProductEntity savedProduct2 = productRepository.save(product2);
@@ -197,8 +198,8 @@ public class ProductServiceIntegrationTest {
                 () -> assertThat(products.size()).isEqualTo(2),
                 () -> assertThat(products.get(0).name()).isEqualTo("운동화1"),
                 () -> assertThat(products.get(1).name()).isEqualTo("운동화2"),
-                () -> assertThat(products.get(0).price()).isEqualTo(10000),
-                () -> assertThat(products.get(1).price()).isEqualTo(20000),
+                () -> assertThat(products.get(0).price()).isEqualByComparingTo(BigDecimal.valueOf(10000)),
+                () -> assertThat(products.get(1).price()).isEqualByComparingTo(BigDecimal.valueOf(20000)),
                 () -> assertThat(products.get(0).stock()).isEqualTo(10),
                 () -> assertThat(products.get(1).stock()).isEqualTo(20)
         );
@@ -217,9 +218,9 @@ public class ProductServiceIntegrationTest {
         ));
 
         BrandEntity brand = brandJpaRepository.save(new BrandEntity("아디다스", "아디다스 입니다."));
-        ProductEntity product1 = new ProductEntity("운동화1", "설명1", 10000, 10, brand.getId());
-        ProductEntity product2 = new ProductEntity("운동화2", "설명2", 20000, 20, brand.getId());
-        ProductEntity product3 = new ProductEntity("운동화3", "설명3", 30000, 30, brand.getId());
+        ProductEntity product1 = new ProductEntity("운동화1", "설명1", BigDecimal.valueOf(10000), 10, brand.getId());
+        ProductEntity product2 = new ProductEntity("운동화2", "설명2", BigDecimal.valueOf(20000), 20, brand.getId());
+        ProductEntity product3 = new ProductEntity("운동화3", "설명3", BigDecimal.valueOf(30000), 30, brand.getId());
 
         ProductEntity savedProduct1 = productRepository.save(product1);
         ProductEntity savedProduct2 = productRepository.save(product2);

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -15,6 +15,8 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.http.HttpMethod.POST;
@@ -83,7 +85,7 @@ public class PointV1ApiE2ETest {
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
                     () -> assertThat(response.getBody()).isNotNull(),
                     () -> assertThat(response.getBody().data().loginId()).isEqualTo(userId),
-                    () -> assertThat(response.getBody().data().amount()).isGreaterThanOrEqualTo(100)
+                    () -> assertThat(response.getBody().data().amount()).isGreaterThanOrEqualTo(BigDecimal.valueOf(100))
             );
         }
 
@@ -126,11 +128,11 @@ public class PointV1ApiE2ETest {
 
             userFacade.signUp(userCriteria);
 
-            Long chargeAmount = 1000L;
+            BigDecimal chargeAmount = BigDecimal.valueOf(1000);
 
             HttpHeaders headers = new HttpHeaders();
             headers.set("X-USER-ID", "loopers123");
-            HttpEntity<Long> requestEntity = new HttpEntity<>(chargeAmount, headers);
+            HttpEntity<BigDecimal> requestEntity = new HttpEntity<>(chargeAmount, headers);
 
             // act
             ParameterizedTypeReference<ApiResponse<PointV1Dto.GetResponse>> responseType = new ParameterizedTypeReference<>() {
@@ -143,9 +145,8 @@ public class PointV1ApiE2ETest {
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
                     () -> assertThat(response.getBody()).isNotNull(),
                     () -> assertThat(response.getBody().data().loginId()).isEqualTo("loopers123"),
-                    () -> assertThat(response.getBody().data().amount()).isEqualTo(1100L) // 초기 100 + 충전 1000
+                    () -> assertThat(response.getBody().data().amount()).isEqualByComparingTo(BigDecimal.valueOf(1100)) // 초기 100 + 충전 1000
             );
-
         }
 
         @DisplayName("존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.")

--- a/docker/grafana/docker-compose.yml
+++ b/docker/grafana/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.4'
+
+networks:
+  k6:
+  grafana:
+
+services:
+  influxdb:
+    image: influxdb:1.8
+    networks:
+      - k6
+      - grafana
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+
+  grafana:
+    image: grafana/grafana:9.3.8
+    networks:
+      - grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    volumes:
+      - ./grafana:/etc/grafana/provisioning/
+
+  k6:
+    image: grafana/k6:latest
+    networks:
+      - k6
+    ports:
+      - "6565:6565"
+    environment:
+      - K6_OUT=influxdb=http://influxdb:8086/k6
+    volumes:
+      - ./examples:/scripts

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -14,8 +14,55 @@ services:
     volumes:
       - mysql-8-data:/var/lib/mysql
 
+  redis-master:
+    image: redis:7.0
+    container_name: redis-master
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_master_data:/data
+    command:
+      [
+        "redis-server", # redis 서버 실행 명령어
+        "--appendonly", "yes", # AOF (AppendOnlyFile) 영속성 기능 켜기
+        "--save", "",
+        "--latency-monitor-threshold", "100", # 특정 command 가 지정 시간(ms) 이상 걸리면 monitor 기록
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  redis-readonly:
+    image: redis:7.0
+    container_name: redis-readonly
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis_readonly_data:/data
+    command:
+      [
+        "redis-server",
+        "--appendonly", "yes",
+        "--appendfsync", "everysec",
+        "--replicaof", "redis-master", "6379", # replica 모드로 실행 + 서비스 명, 서비스 포트
+        "--replica-read-only", "yes", # 읽기 전용으로 설정
+        "--latency-monitor-threshold", "100",
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6380", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
 volumes:
   mysql-8-data:
+  redis_master_data:
+  redis_readonly_data:
 
 networks:
   default:

--- a/k6/get-products-by-brand.js
+++ b/k6/get-products-by-brand.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+    stages: [
+        { duration: '1m', target: 25 },
+    ],
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+export default function () {
+    const brandId = [1, 2, 3, 4, 5][Math.floor(Math.random() * 5)];
+    const page = Math.floor(Math.random() * 3);   // 실제 존재하는 페이지 범위로 제한
+    const size = 20;
+    const sort = 'likeCount,desc';
+    const url = `${BASE_URL}/api/v1/products?brandId=${brandId}&sort=${sort}&page=${page}&size=${size}`;
+
+    const res = http.get(url, { tags: { name: 'GET /api/v1/products' }, responseType: 'none', timeout: '5s' });
+
+    // 상태 코드 확인
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+}

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api("org.springframework.boot:spring-boot-starter-data-redis")
+
+    testFixturesImplementation("com.redis:testcontainers-redis")
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
@@ -1,0 +1,101 @@
+package com.loopers.config.redis;
+
+
+import io.lettuce.core.ReadFrom;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig{
+    private static final String CONNECTION_MASTER = "redisConnectionMaster";
+    public static final String REDIS_TEMPLATE_MASTER = "redisTemplateMaster";
+
+    private final RedisProperties redisProperties;
+
+    public RedisConfig(RedisProperties redisProperties){
+        this.redisProperties = redisProperties;
+    }
+
+    @Primary
+    @Bean
+    public LettuceConnectionFactory defaultRedisConnectionFactory() {
+        int database = redisProperties.database();
+        RedisNodeInfo master = redisProperties.master();
+        List<RedisNodeInfo> replicas = redisProperties.replicas();
+        return lettuceConnectionFactory(
+                database, master, replicas,
+                b -> b.readFrom(ReadFrom.REPLICA_PREFERRED)
+        );
+    }
+
+    @Qualifier(CONNECTION_MASTER)
+    @Bean
+    public LettuceConnectionFactory masterRedisConnectionFactory() {
+        int database = redisProperties.database();
+        RedisNodeInfo master = redisProperties.master();
+        List<RedisNodeInfo> replicas = redisProperties.replicas();
+        return lettuceConnectionFactory(
+                database, master, replicas,
+                b -> b.readFrom(ReadFrom.MASTER)
+        );
+    }
+
+    @Primary
+    @Bean
+    public RedisTemplate<String, String> defaultRedisTemplate(LettuceConnectionFactory lettuceConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        return defaultRedisTemplate(redisTemplate, lettuceConnectionFactory);
+    }
+
+    @Qualifier(REDIS_TEMPLATE_MASTER)
+    @Bean
+    public RedisTemplate<String, String> masterRedisTemplate(
+            @Qualifier(CONNECTION_MASTER) LettuceConnectionFactory lettuceConnectionFactory
+    ) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        return defaultRedisTemplate(redisTemplate, lettuceConnectionFactory);
+    }
+
+
+    private LettuceConnectionFactory lettuceConnectionFactory(
+            int database,
+            RedisNodeInfo master,
+            List<RedisNodeInfo> replicas,
+            Consumer<LettuceClientConfiguration.LettuceClientConfigurationBuilder> customizer
+    ){
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder = LettuceClientConfiguration.builder();
+        if(customizer != null) customizer.accept(builder);
+        LettuceClientConfiguration clientConfig = builder.build();
+        RedisStaticMasterReplicaConfiguration masterReplicaConfig = new RedisStaticMasterReplicaConfiguration(master.host(), master.port());
+        masterReplicaConfig.setDatabase(database);
+        for(RedisNodeInfo r : replicas){
+            masterReplicaConfig.addNode(r.host(), r.port());
+        }
+        return new LettuceConnectionFactory(masterReplicaConfig, clientConfig);
+    }
+
+    private <K,V> RedisTemplate<K,V> defaultRedisTemplate(
+            RedisTemplate<K,V> template,
+            LettuceConnectionFactory connectionFactory
+    ){
+        StringRedisSerializer s = new StringRedisSerializer();
+        template.setKeySerializer(s);
+        template.setValueSerializer(s);
+        template.setHashKeySerializer(s);
+        template.setHashValueSerializer(s);
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisNodeInfo.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisNodeInfo.java
@@ -1,0 +1,6 @@
+package com.loopers.config.redis;
+
+public record RedisNodeInfo(
+        String host,
+        int port
+) { }

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisProperties.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisProperties.java
@@ -1,0 +1,12 @@
+package com.loopers.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(value = "datasource.redis")
+public record RedisProperties(
+        int database,
+        RedisNodeInfo master,
+        List<RedisNodeInfo> replicas
+) { }

--- a/modules/redis/src/main/resources/redis.yml
+++ b/modules/redis/src/main/resources/redis.yml
@@ -1,0 +1,36 @@
+spring:
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+datasource:
+  redis:
+    database: 0
+    master:
+      host: ${REDIS_MASTER_HOST}
+      port: ${REDIS_MASTER_PORT}
+    replicas:
+      - host: ${REDIS_REPLICA_1_HOST}
+        port: ${REDIS_REPLICA_1_PORT}
+
+---
+spring.config.activate.on-profile: local, test
+
+datasource:
+  redis:
+    master:
+      host: localhost
+      port: 6379
+    replicas:
+      - host: localhost
+        port: 6380
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: qa
+
+---
+spring.config.activate.on-profile: prd

--- a/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
@@ -1,0 +1,18 @@
+package com.loopers.testcontainers;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.utility.DockerImageName;
+
+@Configuration
+public class RedisTestContainersConfig {
+    private static final RedisContainer redisContainer = new RedisContainer(DockerImageName.parse("redis:latest"));
+    static {
+        redisContainer.start();
+        System.setProperty("datasource.redis.database", "0");
+        System.setProperty("datasource.redis.master.host", redisContainer.getHost());
+        System.setProperty("datasource.redis.master.port", String.valueOf(redisContainer.getFirstMappedPort()));
+        System.setProperty("datasource.redis.replicas[0].host", redisContainer.getHost());
+        System.setProperty("datasource.redis.replicas[0].port", String.valueOf(redisContainer.getFirstMappedPort()));
+    }
+}

--- a/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
@@ -1,0 +1,20 @@
+package com.loopers.utils;
+
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisCleanUp {
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    public RedisCleanUp(RedisConnectionFactory redisConnectionFactory) {
+        this.redisConnectionFactory = redisConnectionFactory;
+    }
+
+    public void truncateAll(){
+        try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+            connection.serverCommands().flushAll();
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "loopers-commerce"
 include(
     ":apps:commerce-api",
     ":modules:jpa",
+    ":modules:redis",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

### 1. DataFaker 라이브러리를 활용하여 데이터 10만건 준비
### 2. EXPLAIN 및 인덱스 추가
 #### 2-1. 초기 
```json
{
"explain 
	SELECT b.id as brand_id, b.name as brand_name, b.description as brand_desc, 
    p.id as product_id, p.name as product_name, p.price, p.like_count
    FROM product p
    LEFT OUTER JOIN brand b ON p.brand_id = b.id
    WHERE p.brand_id = 1
    AND p.deleted_at IS NULL
    ORDER BY like_count DESC
    LIMIT 0, 20"
: [
	{
		"id" : 1,
		"select_type" : "SIMPLE",
		"table" : "p",
		"partitions" : null,
		"type" : "ALL",
		"possible_keys" : null,
		"key" : null,
		"key_len" : null,
		"ref" : null,
		"rows" : 98393,
		"filtered" : 1.0,
		"Extra" : "Using where; Using filesort"
	},
	{
		"id" : 1,
		"select_type" : "SIMPLE",
		"table" : "b",
		"partitions" : null,
		"type" : "const",
		"possible_keys" : "PRIMARY",
		"key" : "PRIMARY",
		"key_len" : "8",
		"ref" : "const",
		"rows" : 1,
		"filtered" : 100.0,
		"Extra" : null
	}
]}
```

#### 2-2 인덱스 추가
<img width="767" height="49" alt="image" src="https://github.com/user-attachments/assets/473ed9f8-e441-48d7-962e-1701db0dbd0d" />

#### 2-3 다시 조회
```json
{
"explain SELECT
b.id as brand_id, b.name as brand_name, b.description as brand_desc,
p.id as product_id, p.name as product_name, p.price, p.like_count
FROM product p
LEFT OUTER JOIN brand b ON p.brand_id = b.id
WHERE p.brand_id = 1
AND p.deleted_at IS NULL
ORDER BY like_count DESC
LIMIT 0, 20": [
	{
		"id" : 1,
		"select_type" : "SIMPLE",
		"table" : "p",
		"partitions" : null,
		"type" : "ref",
		"possible_keys" : "idx_product_brand_deleted_likecount",
		"key" : "idx_product_brand_deleted_likecount",
		"key_len" : "18",
		"ref" : "const,const",
		"rows" : 993,
		"filtered" : 100.0,
		"Extra" : "Using index condition"
	},
	{
		"id" : 1,
		"select_type" : "SIMPLE",
		"table" : "b",
		"partitions" : null,
		"type" : "const",
		"possible_keys" : "PRIMARY",
		"key" : "PRIMARY",
		"key_len" : "8",
		"ref" : "const",
		"rows" : 1,
		"filtered" : 100.0,
		"Extra" : null
	}
]}
```
#### 2-5. k6를 통한 성능 비교
<img width="392" height="299" alt="image" src="https://github.com/user-attachments/assets/a9083f0a-5e92-4727-916a-03bdad50dfea" />


### 3. 캐시 처리
#### 3-1. redis 연결 및 캐시 처리 후 성능 비교
<img width="392" height="299" alt="image" src="https://github.com/user-attachments/assets/35f658e2-4bf8-4f75-8b53-4527a3f8c8f7" />


### 4. 최종 요약
<img width="567" height="297" alt="image" src="https://github.com/user-attachments/assets/ba4b1763-ecff-4bb3-9e42-45ef8647b304" />


## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

1. 데이터를 넣는 방식에 고민이 있었습니다. 초기 어플리케이션이 실행하면 바로 실행되도록 했는데, 그 다음부터는 다시 저장하지 않도록 하고 싶은데 어떻게 하는게 좋은 방법인지 몰라 초기에 한번 실행하고 실행이 안되도록 해두었는데, 다른 좋은 방법이 혹시 있나 궁금합니다.
2. 현재 인덱스 튜닝만으로도 성능 개선이 컸습니다. 조회 과정에서 캐싱을 적용하면 더 이득을 볼 수 있는 지점이 어디인지 궁금합니다.

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### 🔖 Index

- [ ]  상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다.
- [ ]  조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다. (Optional 카디널리티 분석)

### ❤️ Structure

- [ ]  상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다.
- [ ]  좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다.

### ⚡ Cache

- [ ]  Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다.
- [ ]  캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

- https://www.datafaker.net/documentation/getting-started/