### PR TITLE
[volum-7] ApplicationEvent 을 활용한 트렌젝션 로직 분리

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeEvent.java
@@ -1,0 +1,4 @@
+package com.loopers.application.like;
+
+public record LikeEvent(Long productId, boolean isLike) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -7,8 +7,11 @@ import com.loopers.domain.user.UserEntity;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -20,14 +23,16 @@ public class LikeFacade {
     @Transactional
     public void like(LikeCriteria.Like likeCriteria) {
         UserInfo userInfo = userService.getUserInfo(likeCriteria.loginId());
+        LikeCommand.Like command = likeCriteria.toCommand(userInfo.userId());
 
-        likeService.like(likeCriteria.toCommand(userInfo.userId()));
+        likeService.like(command);
     }
 
     @Transactional
     public void unlike(LikeCriteria.Like likeCriteria) {
         UserInfo userInfo = userService.getUserInfo(likeCriteria.loginId());
+        LikeCommand.Like command = likeCriteria.toCommand(userInfo.userId());
 
-        likeService.unlike(likeCriteria.toCommand(userInfo.userId()));
+        likeService.unlike(command);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/ProductEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/ProductEventListener.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.payment;
+
+import com.loopers.application.like.LikeEvent;
+import com.loopers.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ProductEventListener {
+
+    private final ProductService productService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeEvent(final LikeEvent event) {
+        productService.updateLikeCount(event.productId(), event.isLike());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -81,4 +81,14 @@ public class ProductEntity extends BaseEntity {
         }
         this.stock -= quantity;
     }
+
+    public void increaseLikeCount() {
+        this.likeCount += 1;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount -= 1;
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -84,4 +84,18 @@ public class ProductService {
         List<ProductWithLikeCount> likedProducts = productRepository.findLikedProductsByUserId(userId);
         return likedProducts.stream().map(ProductInfo::from).collect(Collectors.toList());
     }
+
+    @Transactional
+    public void updateLikeCount(Long productId, boolean isLike) {
+        ProductEntity product = productRepository.findById(productId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "해당 상품이 존재하지 않습니다."));
+
+        if (isLike) {
+            product.increaseLikeCount();
+        } else {
+            product.decreaseLikeCount();
+        }
+        
+        productRepository.save(product);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -32,7 +32,7 @@ public class LikeV1Controller implements LikeV1ApiSpec {
             @PathVariable Long productId
     ) {
         LikeV1Dto.LikeRequest likeRequest = new LikeV1Dto.LikeRequest(loginId, productId);
-        likeFacade.like(likeRequest.toCriteria(likeRequest));
+        likeFacade.unlike(likeRequest.toCriteria(likeRequest));
 
         return  ApiResponse.success();
     }

--- a/http/commerce-api/example-v1.http
+++ b/http/commerce-api/example-v1.http
@@ -40,3 +40,11 @@ X-USER-ID: 135135
 GET {{pg-simulator}}/api/v1/payments?orderId=10012312
 X-USER-ID: 135135
 
+
+### 좋아요
+POST {{commerce-api}}/api/v1/like/products/1
+X-USER-ID: loopers123
+
+### 좋아요 취소
+DELETE {{commerce-api}}/api/v1/like/products/1
+X-USER-ID: loopers123


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

- 애플리케이션 이벤트를 활용해 유스케이스의 후속 흐름을 분리하고, 비동기 트랜잭션 흐름 설계
- 좋아요와 상품의 좋아요 수의 로직을 느슨하게 이벤트를 통해서 분리했습니다


## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->


## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

### 🧾 주문 ↔ 결제

- [ ]  **이벤트 기반**으로 주문 트랜잭션과 쿠폰 사용 처리를 분리한다.
- [ ]  **이벤트 기반**으로 결제 결과에 따른 주문 처리를 분리한다.
- [ ]  **이벤트 기반**으로 주문, 결제의 결과에 대한 데이터 플랫폼에 전송하는 후속처리를 진행한다.

### ❤️ 좋아요 ↔ 집계

- [ ]  **이벤트 기반**으로 좋아요 처리와 집계를 분리한다.
- [ ]  집계 로직의 성공/실패와 상관 없이, 좋아요 처리는 정상적으로 완료되어야 한다.

### 📽️ 공통

- [ ]  이벤트 기반으로 `유저의 행동` 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.
    
    
    > *상품 조회, 클릭, 좋아요, 주문 등*
    > 
- [ ]  동작의 주체를 적절하게 분리하고, 트랜잭션 간의 연관관계를 고민해 봅니다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->